### PR TITLE
fix(logo): remove margin ngx-signal-state logo

### DIFF
--- a/logos/ngx-signal-state.svg
+++ b/logos/ngx-signal-state.svg
@@ -1,11 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" viewBox="0 0 250 250" xml:space="preserve" style="enable-background: new 0 0 250 250;">
-<style type="text/css"> .shield-maker-primary { fill: #016767 !important; } .shield-maker-secondary { fill: #015b5b !important; }</style>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 186.2 200">
 <g>
-    <polygon points="125,30 125,30 125,30 31.9,63.2 46.1,186.3 125,230 125,230 125,230 203.9,186.3 218.1,63.2" class="shield-maker-primary"/>
-    <polygon points="125,30 125,52.2 125,52.1 125,153.4 125,153.4 125,230 125,230 203.9,186.3 218.1,63.2 125,30" class="shield-maker-secondary"/>    
-    <rect x="89" y="125" width="12" height="40" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
-    <rect x="107" y="115" width="12" height="50" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
-    <rect x="131" y="105" width="12" height="60" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
-    <rect x="149" y="95" width="12" height="70" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
+    <polygon points="93.1,0 93.1,0 93.1,0 0,33.2 6.2,156.3 93.1,200 93.1,200 93.1,200 172,156.3 186.2,33.2" style="fill: #016767;" />
+    <polygon points="93.1,00 93.1,22.2 93.1,22.1 93.1,123.4 93.1,123.4 93.1,200 93.1,200 172,156.3 186.2,33.2 93.1,0" style="fill: #015b5b" />
+    <rect x="57.1" y="95" width="12" height="40" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
+    <rect x="75.1" y="85" width="12" height="50" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
+    <rect x="99.1" y="75" width="12" height="60" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
+    <rect x="117.1" y="65" width="12" height="70" rx="6"  style="stroke-width: 0; fill:#ffffff;" />
 </g>
 </svg>


### PR DESCRIPTION
## Checklist for logo submission

- [ ] Logo file added to the `logos` folder
- [ ] Created a new entry in `metadata.json` (only `name` is mandatory)
- [ ] Logo is an SVG with vector paths (no embedded pixel image)
- [x] The logo fills the image and there is no white margin (please remove the white margin if there is any 🙂 )