### PR TITLE
fix: add ngx-bar-rating metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -197,6 +197,12 @@
       "license": "MIT",
       "name": "Angular Kenya"
     },
+    "ngx-bar-rating.svg": {
+      "name": "ngx-bar-rating",
+      "creator": "Murhaf Sousli",
+      "license": "MIT",
+      "website": "https://ngx-bar-rating.netlify.app"
+    },
     "ngx-bulma": {
       "name": "ngx-bulma",
       "creator": "ngx-builders",


### PR DESCRIPTION
`ngx-bar-rating.svg` was included in logos folder, but since there was no metadata for it, it will not be displayed.

I think this is a remnant of the time when metadata was not included.  There are other cases.  `angular-extensions` is one.  